### PR TITLE
Fix: Use any opened item for notifying

### DIFF
--- a/openings_notifications.yaml
+++ b/openings_notifications.yaml
@@ -62,6 +62,7 @@ action:
     - condition: state
       entity_id: !input aperture_sensor
       state: 'on'
+      match: any
     sequence:
     - service: notify.send_message
       data:


### PR DESCRIPTION
match: any for running on any aperture leaved open