### PR TITLE
Fix: Use mobile_app domain for notification

### DIFF
--- a/openings_notifications.yaml
+++ b/openings_notifications.yaml
@@ -20,10 +20,10 @@ blueprint:
           multiple: true
     phone_device:
       name: Person device
-      description: People device to use for notification
+      description: Device to use for notification
       selector:
         entity:
-          domain: device_tracker
+          domain: mobile_app
           multiple: true
     message_title:
       name: Title of the message


### PR DESCRIPTION
Uses a mobile_app device domain instead of a tracker